### PR TITLE
Add export for recycle constant

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,8 @@ import * as React from 'react'
 import {AnyAction} from 'redux'
 
 
-export = recycle
-declare const recycle: recycle.Recycle
+export declare const recycle: recycle.Recycle
+export default recycle
 export as namespace recycle
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,6 @@ const Rx = {
   BehaviorSubject
 }
 
-const recycle = component(React, Rx)
+export const recycle = component(React, Rx)
 export { reducer } from './customRxOperators'
 export default recycle


### PR DESCRIPTION
I suggest add an additional export by name.

for example:
```js
import { recycle } from 'recycle';

const App = recycle(...);
```