### PR TITLE
Add type for props in component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
-import {Observable} from 'rxjs'
+import { Observable } from 'rxjs'
 import * as React from 'react'
-import {AnyAction} from 'redux'
+import * as PropTypes from 'prop-types'
+import { AnyAction } from 'redux'
 
 
 export declare const recycle: recycle.Recycle
@@ -180,11 +181,11 @@ declare namespace recycle {
         lifecycle: Observable<ReactLifeCycle>
     }
 
-    interface Params<S, R> {
+    interface Params<P, S, R> {
         /**
          * React props passed by JSX
          */
-        propTypes?: any
+        propTypes?: PropTypes.ValidationMap<P>
 
         /**
          * Determines the html tag name
@@ -263,10 +264,10 @@ declare namespace recycle {
          *     </div>
          *
          */
-        view?: (props: any, state: S) => JSX.Element
+        view?: (props: P, state: S) => JSX.Element
     }
 
     interface Recycle {
-        <S, R=any>(params: recycle.Params<S, R>): React.Component
+        <P, S, R=any>(params: recycle.Params<P, S, R>): React.ComponentClass<P>
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://recycle.js.org",
   "devDependencies": {
+    "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.12",
     "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
The PR add type for props. I inspired by `@types/react` when added generic template. The following order is used in `@types/react`: Props, State. [Proof](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/v15/index.d.ts#L282)

Also corrected the return type. [View explanation](https://stackoverflow.com/a/31815634)

This change breaks compatibility on TypeScript!

Replace 
```typescript
interface AppState {
  ...
}

const App = recycle<AppState>(...);
```

with

```typescript
interface AppProps {
  ...
}
interface AppState {
  ...
}

const App = recycle<AppProps, AppState>(...);
```